### PR TITLE
Update miniquad and imgui dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ repository = "https://github.com/not-fl3/imgui-miniquad-render"
 description = "miniquad based minimal imgui application wrapper"
 
 [dependencies]
-miniquad = { version = "0.3.0-alpha.20" }
+clipboard = "0.5"
+miniquad = { version = "0.3.12" }
 glam = {version = "0.8", features = ["scalar-math"] }
-imgui = { version = "0.5.0" }
+imgui = { version = "0.8.2" }
 
 #[patch.crates-io]
 #miniquad = { path = '../miniquad' }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,5 +1,3 @@
-use imgui::*;
-
 fn main() {
     imgui_miniquad_render::Window::new("Test").main_loop(|ui| {
         let mut opened = true;

--- a/examples/test_window.rs
+++ b/examples/test_window.rs
@@ -1,21 +1,21 @@
 use imgui::*;
 
 fn main() {
-    let mut input = ImString::with_capacity(128);
+    let mut input = String::with_capacity(128);
 
     imgui_miniquad_render::Window::new("Test").main_loop(|ui| {
-        Window::new(im_str!("window_title"))
+        Window::new("window_title")
             .size([300.0, 300.0], Condition::FirstUseEver)
             .build(ui, || {
-                ui.text(im_str!("Hello world!"));
-                ui.text(im_str!("This...is...imgui-rs!"));
+                ui.text("Hello world!");
+                ui.text("This...is...imgui-rs!");
                 ui.separator();
                 let mouse_pos = ui.io().mouse_pos;
                 ui.text(format!(
                     "Mouse Position: ({:.1},{:.1})",
                     mouse_pos[0], mouse_pos[1]
                 ));
-                ui.input_text(im_str!("edit"), &mut input).build();
+                ui.input_text("edit", &mut input).build();
             });
     });
 }

--- a/examples/text_editor.rs
+++ b/examples/text_editor.rs
@@ -2,7 +2,7 @@ use imgui::*;
 use imgui_miniquad_render::platform;
 
 fn main() {
-    let mut text = ImString::with_capacity(10);
+    let mut text = String::with_capacity(10);
 
     imgui_miniquad_render::Window::new("Test")
         .on_init(|imgui| {
@@ -13,7 +13,7 @@ fn main() {
         .main_loop(|ui| {
             let [width, height] = ui.io().display_size;
 
-            Window::new(im_str!("Modbus Testing Tool"))
+            Window::new("Modbus Testing Tool")
                 .position([0.0, 0.0], Condition::Always)
                 .size([width, height], Condition::Always)
                 .title_bar(false)
@@ -21,21 +21,17 @@ fn main() {
                 .menu_bar(true)
                 .build(ui, || {
                     if let Some(menu_bar) = ui.begin_menu_bar() {
-                        if let Some(menu) = ui.begin_menu(im_str!("File"), true) {
-    
-                            if MenuItem::new(im_str!("Exit")).build(ui) {
+                        if let Some(menu) = ui.begin_menu("File") {
+                            if MenuItem::new("Exit").build(ui) {
                                 platform::request_quit();
                             }
-                            menu.end(ui);
+                            menu.end();
                         }
 
-                        menu_bar.end(ui);
+                        menu_bar.end();
                     };
 
-
-                    ui.input_text_multiline(&im_str!(""), &mut text, [-1., -1.])
-                        .resize_buffer(true)
-                        .build();
-                })
+                    ui.input_text_multiline("", &mut text, [-1., -1.]).build();
+                });
         });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,6 @@ impl Stage {
             eprintln!("failed to initialize clipboard!");
         }
 
-        //platform::set_ctx(ctx.clone());
-
         if let Some(on_init) = on_init {
             on_init(&mut imgui);
         }


### PR DESCRIPTION
The EventHandlerFree trait is gone now, so we don't have an owned
Context. Instead implement the EventHandler trait, and leave it for
later to figure out how to support the clipboard.

The imgui demo still has clipboard support...